### PR TITLE
feat: add script to export project files to txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "export:txt": "node scripts/export-to-txt.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/export-to-txt.mjs
+++ b/scripts/export-to-txt.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const projectRoot = path.resolve(process.cwd());
+const outputDir = path.join(projectRoot, 'txt-export');
+const ignored = new Set(['node_modules', '.git', '.vscode', 'dist', 'dist-ssr', 'txt-export']);
+
+async function exportDir(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (ignored.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await exportDir(fullPath);
+    } else if (entry.isFile()) {
+      const relative = path.relative(projectRoot, fullPath);
+      const outPath = path.join(outputDir, relative + '.txt');
+      await fs.mkdir(path.dirname(outPath), { recursive: true });
+      const content = await fs.readFile(fullPath, 'utf8');
+      await fs.writeFile(outPath, content, 'utf8');
+    }
+  }
+}
+
+await fs.rm(outputDir, { recursive: true, force: true });
+await fs.mkdir(outputDir, { recursive: true });
+await exportDir(projectRoot);


### PR DESCRIPTION
## Summary
- add `export-to-txt` script that copies project files to a separate `txt-export` directory while skipping dependency folders
- expose script through `npm run export:txt`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*
- `npm run export:txt`


------
https://chatgpt.com/codex/tasks/task_e_68a516a1ab1c832e9bb271d616caa865