### PR TITLE
Add basic auth backend and frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "export:txt": "node scripts/export-to-txt.mjs"
+    "export:txt": "node scripts/export-to-txt.mjs",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server/db.json
+++ b/server/db.json
@@ -1,0 +1,4 @@
+{
+  "users": [],
+  "subscriptions": []
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,104 @@
+import http from 'http';
+import { readFileSync, writeFileSync } from 'fs';
+import { randomUUID, createHmac, createHash } from 'crypto';
+import url from 'url';
+
+const PORT = 4000;
+const SECRET = 'secret-key';
+
+function readDB() {
+  const data = readFileSync(new URL('./db.json', import.meta.url));
+  return JSON.parse(data.toString());
+}
+
+function writeDB(data) {
+  writeFileSync(new URL('./db.json', import.meta.url), JSON.stringify(data, null, 2));
+}
+
+function generateToken(payload) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = createHmac('sha256', SECRET)
+    .update(`${header}.${body}`)
+    .digest('base64url');
+  return `${header}.${body}.${signature}`;
+}
+
+const server = http.createServer((req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const parsedUrl = url.parse(req.url, true);
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/api/register') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const { email, password } = JSON.parse(body);
+        const db = readDB();
+        if (db.users.find((u) => u.email === email)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'User already exists' }));
+          return;
+        }
+        const user = {
+          id: randomUUID(),
+          email,
+          password: createHash('sha256').update(password).digest('hex'),
+        };
+        db.users.push(user);
+        db.subscriptions.push({ id: randomUUID(), userId: user.id, plan: 'free' });
+        writeDB(db);
+        const token = generateToken({ id: user.id, email: user.email });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ token }));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Server error' }));
+      }
+    });
+    return;
+  }
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/api/login') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const { email, password } = JSON.parse(body);
+        const db = readDB();
+        const user = db.users.find((u) => u.email === email);
+        if (!user || user.password !== createHash('sha256').update(password).digest('hex')) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid credentials' }));
+          return;
+        }
+        const token = generateToken({ id: user.id, email: user.email });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ token }));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Server error' }));
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not Found' }));
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Login from "./pages/Login";
+import Register from "./pages/Register";
+import Dashboard from "./pages/Dashboard";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +19,9 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/dashboard" element={<Dashboard />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+const Dashboard = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      navigate("/login");
+    }
+  }, [navigate]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+      <h1 className="text-2xl font-bold">Bem-vindo ao Dashboard!</h1>
+      <Button>Criar Nova Página</Button>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const Login = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    try {
+      const res = await fetch("http://localhost:4000/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Erro ao fazer login");
+        return;
+      }
+      localStorage.setItem("token", data.token);
+      navigate("/dashboard");
+    } catch {
+      setError("Erro de rede");
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center">Login</h1>
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button type="submit" className="w-full">
+          Entrar
+        </Button>
+        <p className="text-center text-sm">
+          Não tem conta? <Link to="/register" className="underline">Registre-se</Link>
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const Register = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    try {
+      const res = await fetch("http://localhost:4000/api/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Erro ao registrar");
+        return;
+      }
+      localStorage.setItem("token", data.token);
+      navigate("/dashboard");
+    } catch {
+      setError("Erro de rede");
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center">Registrar</h1>
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button type="submit" className="w-full">
+          Criar Conta
+        </Button>
+        <p className="text-center text-sm">
+          Já possui conta? <Link to="/login" className="underline">Entrar</Link>
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export default Register;


### PR DESCRIPTION
## Summary
- implement minimal Node.js backend with JSON storage and JWT-like auth
- add login, register, and dashboard pages saving token to localStorage
- wire up routes and server script

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: pre-existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a51a6ab9b4832ea2c3bc4c537835c6