### PR TITLE
feat: add adaptive theme dashboard

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/ui/theme-templates/netflix-theme.tsx
+++ b/src/components/ui/theme-templates/netflix-theme.tsx
@@ -1,14 +1,28 @@
-import { Card } from "@/components/ui/card";
-import { Play, Plus, ThumbsUp, Share2 } from "lucide-react";
+import { useState } from "react";
+import { Play, Plus, ThumbsUp, Share2, X } from "lucide-react";
+
+interface NetflixMovie {
+  cover: string;
+  video: string;
+}
 
 interface NetflixThemeProps {
   name1: string;
   name2: string;
   uploadedImage?: string;
+  heroVideo?: string;
+  movies?: NetflixMovie[];
 }
 
-const NetflixTheme = ({ name1, name2, uploadedImage }: NetflixThemeProps) => {
+const NetflixTheme = ({
+  name1,
+  name2,
+  uploadedImage,
+  heroVideo,
+  movies = [],
+}: NetflixThemeProps) => {
   const coupleTitle = name1 && name2 ? `${name1} & ${name2}` : "Nossa História";
+  const [activeVideo, setActiveVideo] = useState<string | null>(null);
   
   return (
     <div className="bg-black text-white rounded-lg overflow-hidden min-h-[400px] font-sans">
@@ -23,10 +37,18 @@ const NetflixTheme = ({ name1, name2, uploadedImage }: NetflixThemeProps) => {
       {/* Hero Section */}
       <div className="relative">
         <div className="h-48 bg-gradient-to-r from-red-900 to-red-700 flex items-center justify-center">
-          {uploadedImage ? (
-            <img 
-              src={uploadedImage} 
-              alt="Casal" 
+          {heroVideo ? (
+            <video
+              src={heroVideo}
+              className="w-full h-full object-cover"
+              autoPlay
+              muted
+              loop
+            />
+          ) : uploadedImage ? (
+            <img
+              src={uploadedImage}
+              alt="Casal"
               className="w-full h-full object-cover"
             />
           ) : (
@@ -56,11 +78,41 @@ const NetflixTheme = ({ name1, name2, uploadedImage }: NetflixThemeProps) => {
         <div>
           <h3 className="text-lg font-semibold mb-2">Nossos Momentos Especiais</h3>
           <div className="grid grid-cols-4 gap-2">
-            {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="aspect-video bg-gray-800 rounded flex items-center justify-center text-xs">
-                Ep {i}
-              </div>
-            ))}
+            {movies.length > 0
+              ? movies.map((movie, index) => (
+                  <div
+                    key={index}
+                    className="relative aspect-video bg-gray-800 rounded overflow-hidden"
+                  >
+                    {movie.cover ? (
+                      <img
+                        src={movie.cover}
+                        alt={`Filme ${index + 1}`}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex items-center justify-center w-full h-full text-xs">
+                        Filme {index + 1}
+                      </div>
+                    )}
+                    {movie.video && (
+                      <button
+                        onClick={() => setActiveVideo(movie.video)}
+                        className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 hover:opacity-100 transition"
+                      >
+                        <Play />
+                      </button>
+                    )}
+                  </div>
+                ))
+              : [1, 2, 3, 4].map((i) => (
+                  <div
+                    key={i}
+                    className="aspect-video bg-gray-800 rounded flex items-center justify-center text-xs"
+                  >
+                    Ep {i}
+                  </div>
+                ))}
           </div>
         </div>
 
@@ -80,6 +132,24 @@ const NetflixTheme = ({ name1, name2, uploadedImage }: NetflixThemeProps) => {
           Repleta de momentos inesquecíveis, risadas e muito carinho.
         </p>
       </div>
+      {activeVideo && (
+        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50">
+          <div className="relative w-full max-w-2xl">
+            <button
+              onClick={() => setActiveVideo(null)}
+              className="absolute -top-10 right-0 text-white"
+            >
+              <X size={24} />
+            </button>
+            <video
+              src={activeVideo}
+              controls
+              autoPlay
+              className="w-full h-auto rounded"
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/ui/theme-templates/theme-dashboard.tsx
+++ b/src/components/ui/theme-templates/theme-dashboard.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export type ThemeType =
+  | "netflix"
+  | "spotify"
+  | "instagram"
+  | "polaroid"
+  | "love-letter"
+  | "love-map";
+
+interface ThemeDashboardProps {
+  theme: ThemeType;
+  onSubmit?: (data: unknown) => void;
+}
+
+const ThemeDashboard = ({ theme, onSubmit }: ThemeDashboardProps) => {
+  const [netflixData, setNetflixData] = useState({
+    name1: "",
+    name2: "",
+    heroVideo: "",
+    movies: [{ cover: "", video: "" }],
+  });
+
+  const [genericData, setGenericData] = useState<Record<string, string>>({});
+
+  const handleNetflixMovieChange = (
+    index: number,
+    field: "cover" | "video",
+    value: string
+  ) => {
+    const movies = [...netflixData.movies];
+    movies[index] = { ...movies[index], [field]: value };
+    setNetflixData({ ...netflixData, movies });
+  };
+
+  const addNetflixMovie = () => {
+    setNetflixData({
+      ...netflixData,
+      movies: [...netflixData.movies, { cover: "", video: "" }],
+    });
+  };
+
+  const renderFields = () => {
+    switch (theme) {
+      case "netflix":
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Nome 1</Label>
+                <Input
+                  value={netflixData.name1}
+                  onChange={(e) =>
+                    setNetflixData({ ...netflixData, name1: e.target.value })
+                  }
+                  placeholder="Nome 1"
+                />
+              </div>
+              <div>
+                <Label>Nome 2</Label>
+                <Input
+                  value={netflixData.name2}
+                  onChange={(e) =>
+                    setNetflixData({ ...netflixData, name2: e.target.value })
+                  }
+                  placeholder="Nome 2"
+                />
+              </div>
+            </div>
+            <div>
+              <Label>Vídeo de capa (URL)</Label>
+              <Input
+                value={netflixData.heroVideo}
+                onChange={(e) =>
+                  setNetflixData({
+                    ...netflixData,
+                    heroVideo: e.target.value,
+                  })
+                }
+                placeholder="https://..."
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Filmes</Label>
+              {netflixData.movies.map((movie, index) => (
+                <div key={index} className="grid grid-cols-2 gap-2">
+                  <Input
+                    value={movie.cover}
+                    onChange={(e) =>
+                      handleNetflixMovieChange(index, "cover", e.target.value)
+                    }
+                    placeholder="URL da capa"
+                  />
+                  <Input
+                    value={movie.video}
+                    onChange={(e) =>
+                      handleNetflixMovieChange(index, "video", e.target.value)
+                    }
+                    placeholder="URL do vídeo"
+                  />
+                </div>
+              ))}
+              <Button type="button" variant="outline" onClick={addNetflixMovie}>
+                Adicionar Filme
+              </Button>
+            </div>
+          </div>
+        );
+      case "spotify":
+        return (
+          <div className="space-y-4">
+            <div>
+              <Label>Link da Playlist</Label>
+              <Input
+                value={genericData.playlist || ""}
+                onChange={(e) =>
+                  setGenericData({ ...genericData, playlist: e.target.value })
+                }
+                placeholder="URL da playlist"
+              />
+            </div>
+          </div>
+        );
+      case "polaroid":
+        return (
+          <div className="space-y-4">
+            <div>
+              <Label>Fotos (separadas por vírgula)</Label>
+              <Input
+                value={genericData.photos || ""}
+                onChange={(e) =>
+                  setGenericData({ ...genericData, photos: e.target.value })
+                }
+                placeholder="URL1, URL2, URL3"
+              />
+            </div>
+          </div>
+        );
+      default:
+        return (
+          <div className="text-sm text-muted-foreground">
+            Nenhuma configuração especial para este tema.
+          </div>
+        );
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data =
+      theme === "netflix"
+        ? netflixData
+        : genericData;
+    onSubmit?.(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {renderFields()}
+      <Button type="submit">Salvar</Button>
+    </form>
+  );
+};
+
+export default ThemeDashboard;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -126,5 +127,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- enhance Netflix template with hero video and interactive movie list
- add configurable ThemeDashboard component
- fix various lint issues and use ES module plugin import for Tailwind

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a51b6a0540832eb86b559b00e43f2c