### PR TITLE
Add user login flow and dashboard theme editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Login from "./pages/Login";
+import Dashboard from "./pages/Dashboard";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +18,8 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/dashboard" element={<Dashboard />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
-import Login from "./pages/Login";
+import Auth from "./pages/Auth";
 import Dashboard from "./pages/Dashboard";
 
 const queryClient = new QueryClient();
@@ -18,7 +18,8 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
-          <Route path="/login" element={<Login />} />
+          <Route path="/login" element={<Auth initialMode="login" />} />
+          <Route path="/register" element={<Auth initialMode="register" />} />
           <Route path="/dashboard" element={<Dashboard />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/ui/theme-templates/instagram-theme.tsx
+++ b/src/components/ui/theme-templates/instagram-theme.tsx
@@ -1,14 +1,14 @@
-import { Card } from "@/components/ui/card";
 import { Heart, MessageCircle, Send, Bookmark, MoreHorizontal } from "lucide-react";
 
 interface InstagramThemeProps {
   name1: string;
   name2: string;
   uploadedImage?: string;
+  caption?: string;
 }
 
-const InstagramTheme = ({ name1, name2, uploadedImage }: InstagramThemeProps) => {
-  const username = name1 ? name1.toLowerCase().replace(' ', '_') : "nosso_amor";
+const InstagramTheme = ({ name1, name2, uploadedImage, caption }: InstagramThemeProps) => {
+  const username = name1 ? name1.toLowerCase().replace(" ", "_") : "nosso_amor";
   
   return (
     <div className="bg-white rounded-lg overflow-hidden min-h-[400px] font-sans border">
@@ -22,7 +22,9 @@ const InstagramTheme = ({ name1, name2, uploadedImage }: InstagramThemeProps) =>
           </div>
           <div>
             <div className="font-semibold text-sm">{username}</div>
-            <div className="text-xs text-gray-500">Local especial</div>
+            <div className="text-xs text-gray-500">
+              {name2 ? `com ${name2}` : "Local especial"}
+            </div>
           </div>
         </div>
         <MoreHorizontal size={20} />
@@ -57,7 +59,8 @@ const InstagramTheme = ({ name1, name2, uploadedImage }: InstagramThemeProps) =>
           <div className="text-sm">
             <span className="font-semibold">{username}</span>{" "}
             <span>
-              Cada momento ao seu lado é especial 💕 {name2 && `@${name2.toLowerCase().replace(' ', '_')}`} #amor #momentosespeciais #gratidao
+              {caption || "Cada momento ao seu lado é especial 💕"}
+              {name2 && ` @${name2.toLowerCase().replace(" ", "_")}`}
             </span>
           </div>
           <div className="text-gray-500 text-xs">Ver todos os 42 comentários</div>

--- a/src/components/ui/theme-templates/netflix-theme.tsx
+++ b/src/components/ui/theme-templates/netflix-theme.tsx
@@ -1,14 +1,28 @@
-import { Card } from "@/components/ui/card";
-import { Play, Plus, ThumbsUp, Share2 } from "lucide-react";
+import { useState } from "react";
+import { Play, Plus, ThumbsUp, Share2, X } from "lucide-react";
+
+interface NetflixMovie {
+  cover: string;
+  video: string;
+}
 
 interface NetflixThemeProps {
   name1: string;
   name2: string;
   uploadedImage?: string;
+  heroVideo?: string;
+  movies?: NetflixMovie[];
 }
 
-const NetflixTheme = ({ name1, name2, uploadedImage }: NetflixThemeProps) => {
+const NetflixTheme = ({
+  name1,
+  name2,
+  uploadedImage,
+  heroVideo,
+  movies = [],
+}: NetflixThemeProps) => {
   const coupleTitle = name1 && name2 ? `${name1} & ${name2}` : "Nossa História";
+  const [activeVideo, setActiveVideo] = useState<string | null>(null);
   
   return (
     <div className="bg-black text-white rounded-lg overflow-hidden min-h-[400px] font-sans">
@@ -23,10 +37,18 @@ const NetflixTheme = ({ name1, name2, uploadedImage }: NetflixThemeProps) => {
       {/* Hero Section */}
       <div className="relative">
         <div className="h-48 bg-gradient-to-r from-red-900 to-red-700 flex items-center justify-center">
-          {uploadedImage ? (
-            <img 
-              src={uploadedImage} 
-              alt="Casal" 
+          {heroVideo ? (
+            <video
+              src={heroVideo}
+              className="w-full h-full object-cover"
+              autoPlay
+              muted
+              loop
+            />
+          ) : uploadedImage ? (
+            <img
+              src={uploadedImage}
+              alt="Casal"
               className="w-full h-full object-cover"
             />
           ) : (
@@ -56,11 +78,41 @@ const NetflixTheme = ({ name1, name2, uploadedImage }: NetflixThemeProps) => {
         <div>
           <h3 className="text-lg font-semibold mb-2">Nossos Momentos Especiais</h3>
           <div className="grid grid-cols-4 gap-2">
-            {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="aspect-video bg-gray-800 rounded flex items-center justify-center text-xs">
-                Ep {i}
-              </div>
-            ))}
+            {movies.length > 0
+              ? movies.map((movie, index) => (
+                  <div
+                    key={index}
+                    className="relative aspect-video bg-gray-800 rounded overflow-hidden"
+                  >
+                    {movie.cover ? (
+                      <img
+                        src={movie.cover}
+                        alt={`Filme ${index + 1}`}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex items-center justify-center w-full h-full text-xs">
+                        Filme {index + 1}
+                      </div>
+                    )}
+                    {movie.video && (
+                      <button
+                        onClick={() => setActiveVideo(movie.video)}
+                        className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 hover:opacity-100 transition"
+                      >
+                        <Play />
+                      </button>
+                    )}
+                  </div>
+                ))
+              : [1, 2, 3, 4].map((i) => (
+                  <div
+                    key={i}
+                    className="aspect-video bg-gray-800 rounded flex items-center justify-center text-xs"
+                  >
+                    Ep {i}
+                  </div>
+                ))}
           </div>
         </div>
 
@@ -80,6 +132,24 @@ const NetflixTheme = ({ name1, name2, uploadedImage }: NetflixThemeProps) => {
           Repleta de momentos inesquecíveis, risadas e muito carinho.
         </p>
       </div>
+      {activeVideo && (
+        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50">
+          <div className="relative w-full max-w-2xl">
+            <button
+              onClick={() => setActiveVideo(null)}
+              className="absolute -top-10 right-0 text-white"
+            >
+              <X size={24} />
+            </button>
+            <video
+              src={activeVideo}
+              controls
+              autoPlay
+              className="w-full h-auto rounded"
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/ui/theme-templates/spotify-theme.tsx
+++ b/src/components/ui/theme-templates/spotify-theme.tsx
@@ -1,21 +1,42 @@
-import { Card } from "@/components/ui/card";
+import { useRef, useState } from "react";
 import { Play, Heart, MoreHorizontal, Shuffle, SkipBack, SkipForward, Repeat } from "lucide-react";
+
+interface SpotifySong {
+  title: string;
+  artist: string;
+  audio?: string;
+  duration?: string;
+}
 
 interface SpotifyThemeProps {
   name1: string;
   name2: string;
   uploadedImage?: string;
+  songs?: SpotifySong[];
 }
 
-const SpotifyTheme = ({ name1, name2, uploadedImage }: SpotifyThemeProps) => {
+const defaultSongs: SpotifySong[] = [
+  { title: "Perfect", artist: "Ed Sheeran", duration: "4:23" },
+  { title: "All of Me", artist: "John Legend", duration: "4:29" },
+  { title: "Thinking Out Loud", artist: "Ed Sheeran", duration: "4:41" },
+  { title: "A Thousand Years", artist: "Christina Perri", duration: "4:45" },
+];
+
+const SpotifyTheme = ({ name1, name2, uploadedImage, songs = [] }: SpotifyThemeProps) => {
   const playlistName = name1 && name2 ? `${name1} & ${name2}` : "Nossa Playlist";
-  
-  const songs = [
-    { title: "Perfect", artist: "Ed Sheeran", duration: "4:23" },
-    { title: "All of Me", artist: "John Legend", duration: "4:29" },
-    { title: "Thinking Out Loud", artist: "Ed Sheeran", duration: "4:41" },
-    { title: "A Thousand Years", artist: "Christina Perri", duration: "4:45" }
-  ];
+  const songList = songs.length > 0 ? songs : defaultSongs;
+  const [currentSong, setCurrentSong] = useState<SpotifySong | null>(
+    songList[0] || null
+  );
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  const playSong = (song: SpotifySong) => {
+    setCurrentSong(song);
+    if (audioRef.current && song.audio) {
+      audioRef.current.src = song.audio;
+      audioRef.current.play().catch(() => {});
+    }
+  };
 
   return (
     <div className="bg-gradient-to-b from-green-900 to-black text-white rounded-lg overflow-hidden min-h-[400px] font-sans">
@@ -45,7 +66,7 @@ const SpotifyTheme = ({ name1, name2, uploadedImage }: SpotifyThemeProps) => {
           <p className="text-sm uppercase tracking-wider">Playlist</p>
           <h1 className="text-4xl md:text-6xl font-bold">{playlistName}</h1>
           <p className="text-gray-300">
-            {name1 || "Você"} • {songs.length} músicas, aproximadamente 18 min
+            {name1 || "Você"} • {songList.length} músicas
           </p>
         </div>
       </div>
@@ -67,10 +88,11 @@ const SpotifyTheme = ({ name1, name2, uploadedImage }: SpotifyThemeProps) => {
           <div className="col-span-3 text-right">DURAÇÃO</div>
         </div>
         
-        {songs.map((song, index) => (
-          <div 
-            key={index} 
-            className="grid grid-cols-12 gap-4 py-2 hover:bg-white/10 rounded group text-sm"
+        {songList.map((song, index) => (
+          <div
+            key={index}
+            className="grid grid-cols-12 gap-4 py-2 hover:bg-white/10 rounded group text-sm cursor-pointer"
+            onClick={() => playSong(song)}
           >
             <div className="col-span-1 text-gray-400 group-hover:hidden">
               {index + 1}
@@ -96,19 +118,26 @@ const SpotifyTheme = ({ name1, name2, uploadedImage }: SpotifyThemeProps) => {
             💕
           </div>
           <div>
-            <div className="text-sm font-medium">Perfect</div>
-            <div className="text-xs text-gray-400">Ed Sheeran</div>
+            <div className="text-sm font-medium">
+              {currentSong?.title || "Selecione uma música"}
+            </div>
+            <div className="text-xs text-gray-400">
+              {currentSong?.artist}
+            </div>
           </div>
         </div>
-        
+
         <div className="flex items-center gap-4">
           <Shuffle size={16} className="text-gray-400" />
           <SkipBack size={16} />
-          <Play size={16} />
+          <button onClick={() => currentSong && playSong(currentSong)}>
+            <Play size={16} />
+          </button>
           <SkipForward size={16} />
           <Repeat size={16} className="text-gray-400" />
         </div>
       </div>
+      <audio ref={audioRef} className="hidden" />
     </div>
   );
 };

--- a/src/components/ui/theme-templates/theme-dashboard.tsx
+++ b/src/components/ui/theme-templates/theme-dashboard.tsx
@@ -1,0 +1,336 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export type ThemeType =
+  | "netflix"
+  | "spotify"
+  | "instagram"
+  | "polaroid"
+  | "love-letter"
+  | "love-map";
+
+interface ThemeDashboardProps {
+  theme: ThemeType;
+  onSubmit?: (data: unknown) => void;
+}
+
+const ThemeDashboard = ({ theme, onSubmit }: ThemeDashboardProps) => {
+  const [netflixData, setNetflixData] = useState({
+    name1: "",
+    name2: "",
+    uploadedImage: "",
+    heroVideo: "",
+    movies: [{ cover: "", video: "" }],
+  });
+
+  const [spotifyData, setSpotifyData] = useState({
+    name1: "",
+    name2: "",
+    coverImage: "",
+    songs: [{ title: "", artist: "", audio: "", duration: "" }],
+  });
+
+  const [instagramData, setInstagramData] = useState({
+    name1: "",
+    name2: "",
+    image: "",
+    caption: "",
+  });
+
+  const [genericData, setGenericData] = useState<Record<string, string>>({});
+
+  const handleNetflixMovieChange = (
+    index: number,
+    field: "cover" | "video",
+    value: string
+  ) => {
+    const movies = [...netflixData.movies];
+    movies[index] = { ...movies[index], [field]: value };
+    setNetflixData({ ...netflixData, movies });
+  };
+
+  const addNetflixMovie = () => {
+    setNetflixData({
+      ...netflixData,
+      movies: [...netflixData.movies, { cover: "", video: "" }],
+    });
+  };
+
+  const renderFields = () => {
+    switch (theme) {
+      case "netflix":
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Nome 1</Label>
+                <Input
+                  value={netflixData.name1}
+                  onChange={(e) =>
+                    setNetflixData({ ...netflixData, name1: e.target.value })
+                  }
+                  placeholder="Nome 1"
+                />
+              </div>
+              <div>
+                <Label>Nome 2</Label>
+                <Input
+                  value={netflixData.name2}
+                  onChange={(e) =>
+                    setNetflixData({ ...netflixData, name2: e.target.value })
+                  }
+                  placeholder="Nome 2"
+                />
+              </div>
+            </div>
+            <div>
+              <Label>Imagem de capa (URL)</Label>
+              <Input
+                value={netflixData.uploadedImage}
+                onChange={(e) =>
+                  setNetflixData({
+                    ...netflixData,
+                    uploadedImage: e.target.value,
+                  })
+                }
+                placeholder="https://..."
+              />
+            </div>
+            <div>
+              <Label>Vídeo de capa (URL)</Label>
+              <Input
+                value={netflixData.heroVideo}
+                onChange={(e) =>
+                  setNetflixData({
+                    ...netflixData,
+                    heroVideo: e.target.value,
+                  })
+                }
+                placeholder="https://..."
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Filmes</Label>
+              {netflixData.movies.map((movie, index) => (
+                <div key={index} className="grid grid-cols-2 gap-2">
+                  <Input
+                    value={movie.cover}
+                    onChange={(e) =>
+                      handleNetflixMovieChange(index, "cover", e.target.value)
+                    }
+                    placeholder="URL da capa"
+                  />
+                  <Input
+                    value={movie.video}
+                    onChange={(e) =>
+                      handleNetflixMovieChange(index, "video", e.target.value)
+                    }
+                    placeholder="URL do vídeo"
+                  />
+                </div>
+              ))}
+              <Button type="button" variant="outline" onClick={addNetflixMovie}>
+                Adicionar Filme
+              </Button>
+            </div>
+          </div>
+        );
+      case "spotify":
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Nome 1</Label>
+                <Input
+                  value={spotifyData.name1}
+                  onChange={(e) =>
+                    setSpotifyData({ ...spotifyData, name1: e.target.value })
+                  }
+                  placeholder="Nome 1"
+                />
+              </div>
+              <div>
+                <Label>Nome 2</Label>
+                <Input
+                  value={spotifyData.name2}
+                  onChange={(e) =>
+                    setSpotifyData({ ...spotifyData, name2: e.target.value })
+                  }
+                  placeholder="Nome 2"
+                />
+              </div>
+            </div>
+            <div>
+              <Label>Capa da playlist (URL)</Label>
+              <Input
+                value={spotifyData.coverImage}
+                onChange={(e) =>
+                  setSpotifyData({
+                    ...spotifyData,
+                    coverImage: e.target.value,
+                  })
+                }
+                placeholder="https://..."
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Músicas</Label>
+              {spotifyData.songs.map((song, index) => (
+                <div key={index} className="grid grid-cols-4 gap-2">
+                  <Input
+                    value={song.title}
+                    onChange={(e) => {
+                      const songs = [...spotifyData.songs];
+                      songs[index] = { ...songs[index], title: e.target.value };
+                      setSpotifyData({ ...spotifyData, songs });
+                    }}
+                    placeholder="Título"
+                  />
+                  <Input
+                    value={song.artist}
+                    onChange={(e) => {
+                      const songs = [...spotifyData.songs];
+                      songs[index] = { ...songs[index], artist: e.target.value };
+                      setSpotifyData({ ...spotifyData, songs });
+                    }}
+                    placeholder="Artista"
+                  />
+                  <Input
+                    value={song.audio}
+                    onChange={(e) => {
+                      const songs = [...spotifyData.songs];
+                      songs[index] = { ...songs[index], audio: e.target.value };
+                      setSpotifyData({ ...spotifyData, songs });
+                    }}
+                    placeholder="URL do áudio"
+                  />
+                  <Input
+                    value={song.duration}
+                    onChange={(e) => {
+                      const songs = [...spotifyData.songs];
+                      songs[index] = { ...songs[index], duration: e.target.value };
+                      setSpotifyData({ ...spotifyData, songs });
+                    }}
+                    placeholder="Duração"
+                  />
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  setSpotifyData({
+                    ...spotifyData,
+                    songs: [
+                      ...spotifyData.songs,
+                      { title: "", artist: "", audio: "", duration: "" },
+                    ],
+                  })
+                }
+              >
+                Adicionar Música
+              </Button>
+            </div>
+          </div>
+        );
+      case "instagram":
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Nome 1</Label>
+                <Input
+                  value={instagramData.name1}
+                  onChange={(e) =>
+                    setInstagramData({ ...instagramData, name1: e.target.value })
+                  }
+                  placeholder="Nome 1"
+                />
+              </div>
+              <div>
+                <Label>Nome 2</Label>
+                <Input
+                  value={instagramData.name2}
+                  onChange={(e) =>
+                    setInstagramData({ ...instagramData, name2: e.target.value })
+                  }
+                  placeholder="Nome 2"
+                />
+              </div>
+            </div>
+            <div>
+              <Label>Imagem do post (URL)</Label>
+              <Input
+                value={instagramData.image}
+                onChange={(e) =>
+                  setInstagramData({
+                    ...instagramData,
+                    image: e.target.value,
+                  })
+                }
+                placeholder="https://..."
+              />
+            </div>
+            <div>
+              <Label>Legenda</Label>
+              <Input
+                value={instagramData.caption}
+                onChange={(e) =>
+                  setInstagramData({
+                    ...instagramData,
+                    caption: e.target.value,
+                  })
+                }
+                placeholder="Nossa história..."
+              />
+            </div>
+          </div>
+        );
+      case "polaroid":
+        return (
+          <div className="space-y-4">
+            <div>
+              <Label>Fotos (separadas por vírgula)</Label>
+              <Input
+                value={genericData.photos || ""}
+                onChange={(e) =>
+                  setGenericData({ ...genericData, photos: e.target.value })
+                }
+                placeholder="URL1, URL2, URL3"
+              />
+            </div>
+          </div>
+        );
+      default:
+        return (
+          <div className="text-sm text-muted-foreground">
+            Nenhuma configuração especial para este tema.
+          </div>
+        );
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data =
+      theme === "netflix"
+        ? netflixData
+        : theme === "spotify"
+        ? spotifyData
+        : theme === "instagram"
+        ? instagramData
+        : genericData;
+    onSubmit?.(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {renderFields()}
+      <Button type="submit">Salvar</Button>
+    </form>
+  );
+};
+
+export default ThemeDashboard;

--- a/src/components/ui/theme-templates/theme-dashboard.tsx
+++ b/src/components/ui/theme-templates/theme-dashboard.tsx
@@ -39,6 +39,18 @@ const ThemeDashboard = ({ theme, onSubmit }: ThemeDashboardProps) => {
     caption: "",
   });
 
+  const [loveLetterData, setLoveLetterData] = useState({
+    name1: "",
+    name2: "",
+    uploadedImage: "",
+  });
+
+  const [loveMapData, setLoveMapData] = useState({
+    name1: "",
+    name2: "",
+    uploadedImage: "",
+  });
+
   const [genericData, setGenericData] = useState<Record<string, string>>({});
 
   const handleNetflixMovieChange = (
@@ -303,6 +315,86 @@ const ThemeDashboard = ({ theme, onSubmit }: ThemeDashboardProps) => {
             </div>
           </div>
         );
+      case "love-letter":
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Nome 1</Label>
+                <Input
+                  value={loveLetterData.name1}
+                  onChange={(e) =>
+                    setLoveLetterData({ ...loveLetterData, name1: e.target.value })
+                  }
+                  placeholder="Nome 1"
+                />
+              </div>
+              <div>
+                <Label>Nome 2</Label>
+                <Input
+                  value={loveLetterData.name2}
+                  onChange={(e) =>
+                    setLoveLetterData({ ...loveLetterData, name2: e.target.value })
+                  }
+                  placeholder="Nome 2"
+                />
+              </div>
+            </div>
+            <div>
+              <Label>Imagem (URL)</Label>
+              <Input
+                value={loveLetterData.uploadedImage}
+                onChange={(e) =>
+                  setLoveLetterData({
+                    ...loveLetterData,
+                    uploadedImage: e.target.value,
+                  })
+                }
+                placeholder="https://..."
+              />
+            </div>
+          </div>
+        );
+      case "love-map":
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Nome 1</Label>
+                <Input
+                  value={loveMapData.name1}
+                  onChange={(e) =>
+                    setLoveMapData({ ...loveMapData, name1: e.target.value })
+                  }
+                  placeholder="Nome 1"
+                />
+              </div>
+              <div>
+                <Label>Nome 2</Label>
+                <Input
+                  value={loveMapData.name2}
+                  onChange={(e) =>
+                    setLoveMapData({ ...loveMapData, name2: e.target.value })
+                  }
+                  placeholder="Nome 2"
+                />
+              </div>
+            </div>
+            <div>
+              <Label>Imagem (URL)</Label>
+              <Input
+                value={loveMapData.uploadedImage}
+                onChange={(e) =>
+                  setLoveMapData({
+                    ...loveMapData,
+                    uploadedImage: e.target.value,
+                  })
+                }
+                placeholder="https://..."
+              />
+            </div>
+          </div>
+        );
       default:
         return (
           <div className="text-sm text-muted-foreground">
@@ -321,6 +413,10 @@ const ThemeDashboard = ({ theme, onSubmit }: ThemeDashboardProps) => {
         ? spotifyData
         : theme === "instagram"
         ? instagramData
+        : theme === "love-letter"
+        ? loveLetterData
+        : theme === "love-map"
+        ? loveMapData
         : genericData;
     onSubmit?.(data);
   };

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,0 +1,12 @@
+import Login from "./Login";
+import Register from "./Register";
+
+interface AuthProps {
+  initialMode: "login" | "register";
+}
+
+const Auth = ({ initialMode }: AuthProps) => {
+  return initialMode === "register" ? <Register /> : <Login />;
+};
+
+export default Auth;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import ThemeDashboard, { type ThemeType } from "@/components/ui/theme-templates/theme-dashboard";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+
+const Dashboard = () => {
+  const navigate = useNavigate();
+  const [theme, setTheme] = useState<ThemeType>("netflix");
+
+  useEffect(() => {
+    if (localStorage.getItem("loggedIn") !== "true") {
+      navigate("/login");
+    }
+  }, [navigate]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="max-w-xs space-y-2">
+        <Label>Tema</Label>
+        <Select value={theme} onValueChange={(v) => setTheme(v as ThemeType)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Selecione um tema" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="netflix">Netflix</SelectItem>
+            <SelectItem value="spotify">Spotify</SelectItem>
+            <SelectItem value="instagram">Instagram</SelectItem>
+            <SelectItem value="polaroid">Polaroid</SelectItem>
+            <SelectItem value="love-letter">Love Letter</SelectItem>
+            <SelectItem value="love-map">Love Map</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <ThemeDashboard theme={theme} onSubmit={(data) => console.log(data)} />
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,7 +15,8 @@ const Dashboard = () => {
   const [theme, setTheme] = useState<ThemeType>("netflix");
 
   useEffect(() => {
-    if (localStorage.getItem("loggedIn") !== "true") {
+    const token = localStorage.getItem("token");
+    if (!token) {
       navigate("/login");
     }
   }, [navigate]);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+const Login = () => {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Simple mock login
+    localStorage.setItem("loggedIn", "true");
+    navigate("/dashboard");
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Senha</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <Button type="submit" className="w-full">
+          Entrar
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -3,7 +3,8 @@ import { Link, useNavigate } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
-const Login = () => {
+const Register = () => {
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -13,14 +14,14 @@ const Login = () => {
     e.preventDefault();
     setError("");
     try {
-      const res = await fetch("http://localhost:4000/api/login", {
+      const res = await fetch("http://localhost:4000/api/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ name, email, password }),
       });
       const data = await res.json();
       if (!res.ok) {
-        setError(data.error || "Erro ao fazer login");
+        setError(data.error || "Erro ao registrar");
         return;
       }
       localStorage.setItem("token", data.token);
@@ -33,7 +34,14 @@ const Login = () => {
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-        <h1 className="text-2xl font-bold text-center">Login</h1>
+        <h1 className="text-2xl font-bold text-center">Registrar</h1>
+        <Input
+          type="text"
+          placeholder="Nome"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
         <Input
           type="email"
           placeholder="Email"
@@ -50,14 +58,14 @@ const Login = () => {
         />
         {error && <p className="text-sm text-red-500">{error}</p>}
         <Button type="submit" className="w-full">
-          Entrar
+          Registrar
         </Button>
         <p className="text-center text-sm">
-          Não tem conta? <Link to="/register" className="underline">Registre-se</Link>
+          Já tem conta? <Link to="/login" className="underline">Entrar</Link>
         </p>
       </form>
     </div>
   );
 };
 
-export default Login;
+export default Register;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -126,5 +127,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add login page with mock authentication and redirect to dashboard
- create dashboard page with theme selector and ThemeDashboard component
- register login and dashboard routes in App routing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a51b6a0540832eb86b559b00e43f2c