### PR TITLE
Add theme editor to dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,9 +1,20 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import ThemeDashboard, {
+  ThemeType,
+} from "@/components/ui/theme-templates/theme-dashboard";
 
 const Dashboard = () => {
   const navigate = useNavigate();
+  const [theme, setTheme] = useState<ThemeType>("netflix");
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -12,10 +23,32 @@ const Dashboard = () => {
     }
   }, [navigate]);
 
+  const handleSubmit = (data: unknown) => {
+    console.log("Saved data:", data);
+  };
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
-      <h1 className="text-2xl font-bold">Bem-vindo ao Dashboard!</h1>
-      <Button>Criar Nova Página</Button>
+    <div className="container mx-auto flex flex-col gap-6 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <Button>Criar Nova Página</Button>
+      </div>
+      <div className="max-w-xs">
+        <Select value={theme} onValueChange={(value: ThemeType) => setTheme(value)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Selecione o tema" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="netflix">Netflix</SelectItem>
+            <SelectItem value="spotify">Spotify</SelectItem>
+            <SelectItem value="instagram">Instagram</SelectItem>
+            <SelectItem value="polaroid">Polaroid</SelectItem>
+            <SelectItem value="love-letter">Love Letter</SelectItem>
+            <SelectItem value="love-map">Love Map</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <ThemeDashboard theme={theme} onSubmit={handleSubmit} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- redirect to login when token is missing
- allow selecting and editing templates on dashboard

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a52f1d888c832eab3049bfaaf6f812