### PR TITLE
feat: add login fetch and register link

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -19,14 +19,14 @@ const Login = () => {
         body: JSON.stringify({ email, password }),
       });
       const data = await res.json();
-      if (!res.ok) {
+      if (!res.ok || !data.token) {
         setError(data.error || "Erro ao fazer login");
         return;
       }
       localStorage.setItem("token", data.token);
       navigate("/dashboard");
-    } catch {
-      setError("Erro de rede");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro de rede");
     }
   };
 


### PR DESCRIPTION
## Summary
- handle login via POST to backend and store token on success
- show error messages and navigate to dashboard when authenticated

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a52f1f0618832e91482b3b359e02f5